### PR TITLE
New, tree-compatible options.excludeDirs.

### DIFF
--- a/lib/readdir-plus.js
+++ b/lib/readdir-plus.js
@@ -160,11 +160,13 @@ function doReadDir(path, options, callback, shared) {
 			if ((!detailedFilters && doFilter(res, options.filter))
 				|| (detailedFilters && doFilter(res, options.filter.any) && doFilter(res, options.filter[fileType]))) {
 				results.push(res);
-			}
 
-			if (options.recursive && isDirectory) {
+			} 
+
+			if (options.recursive && isDirectory && options.excludeDirs.indexOf(res.relativePath) == -1) {
 				doRecurse(fullPath, res);
 			}
+			
 			if (options.content.enabled && shared.details && fileType === libVars.FILE_TYPES.file) {
 				doReadContent(res, stat);
 			}


### PR DESCRIPTION
New, tree-compatible options.excludeDirs, array of directories
(relative paths) that we don't want to traverse.
